### PR TITLE
Fix compiler warnings

### DIFF
--- a/ext/ruby_nmatrix.c
+++ b/ext/ruby_nmatrix.c
@@ -1142,8 +1142,49 @@ VALUE nm_eqeq(VALUE self, VALUE another){
   Data_Get_Struct(self, nmatrix, left);
   Data_Get_Struct(another, nmatrix, right);
 
-  switch (right->dtype) {
-    case nm_float64: {
+  if(left->count != right->count){
+    return Qfalse;
+  }
+
+  switch(right->dtype) {
+    case nm_bool: 
+    {
+      bool* left_elements = (bool*)left->elements;
+      bool* right_elements = (bool*)right->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        if(left_elements[index] != right_elements[index]){
+          return Qfalse;
+        }
+      }
+      break;
+    }
+    case nm_int: 
+    {
+      int* left_elements = (int*)left->elements;
+      int* right_elements = (int*)right->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        if(left_elements[index] != right_elements[index]){
+          return Qfalse;
+        }
+      }
+      break;
+    }
+    case nm_float32: 
+    {
+      float* left_elements = (float*)left->elements;
+      float* right_elements = (float*)right->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        if(fabs(left_elements[index] - right_elements[index]) > 1e-3){
+          return Qfalse;
+        }
+      }
+      break;
+    }
+    case nm_float64: 
+    {
       double* left_elements = (double*)left->elements;
       double* right_elements = (double*)right->elements;
 
@@ -1154,13 +1195,25 @@ VALUE nm_eqeq(VALUE self, VALUE another){
       }
       break;
     }
-
-    case nm_float32: {
-      float* left_elements = (float*)left->elements;
-      float* right_elements = (float*)right->elements;
+    case nm_complex32: 
+    {
+      float complex* left_elements = (float complex*)left->elements;
+      float complex* right_elements = (float complex*)right->elements;
 
       for(size_t index = 0; index < left->count; index++){
-        if(fabs(left_elements[index] - right_elements[index]) > 1e-3){
+        if(cabs(left_elements[index] - right_elements[index]) > 1e-3){
+          return Qfalse;
+        }
+      }
+      break;
+    }
+    case nm_complex64: 
+    {
+      double complex* left_elements = (double complex*)left->elements;
+      double complex* right_elements = (double complex*)right->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        if(cabs(left_elements[index] - right_elements[index]) > 1e-3){
           return Qfalse;
         }
       }
@@ -1174,7 +1227,7 @@ VALUE nm_eqeq(VALUE self, VALUE another){
 /*
  * Greater operator.
  * Returns a single true or false value indicating whether
- * the element in a matrix is greater or smaller
+ * the element in a matrix is greater or smaller than given value
  *
  */
 VALUE nm_gt(VALUE self, VALUE another){
@@ -1194,6 +1247,33 @@ VALUE nm_gt(VALUE self, VALUE another){
   bool* result_elements = ALLOC_N(bool, result->shape[0] * result->shape[1]);
 
   switch (left->dtype) {
+    case nm_bool: {
+      double rha = NUM2DBL(another);
+      bool* left_elements = (bool*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] > rha) ? true : false);
+      }
+      break;
+    }
+    case nm_int: {
+      double rha = NUM2DBL(another);
+      int* left_elements = (int*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] > rha) ? true : false);
+      }
+      break;
+    }
+    case nm_float32: {
+      double rha = NUM2DBL(another);
+      float* left_elements = (float*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] > rha) ? true : false);
+      }
+      break;
+    }
     case nm_float64: {
       double rha = NUM2DBL(another);
       double* left_elements = (double*)left->elements;
@@ -1201,6 +1281,26 @@ VALUE nm_gt(VALUE self, VALUE another){
       for(size_t index = 0; index < left->count; index++){
         result_elements[index] = ((left_elements[index] > rha) ? true : false);
       }
+      break;
+    }
+    case nm_complex32: {
+      rb_raise(rb_eSyntaxError, "SyntaxError: nm_complex32 does not support this operator.");
+      // float complex rha = CMPLXF(NUM2DBL(rb_funcall(another, rb_intern("real"), 0, Qnil)), NUM2DBL(rb_funcall(another, rb_intern("imaginary"), 0, Qnil)));;
+      // float complex* left_elements = (float complex*)left->elements;
+
+      // for(size_t index = 0; index < left->count; index++){
+      //   result_elements[index] = ((left_elements[index] > rha) ? true : false);
+      // }
+      break;
+    }
+    case nm_complex64: {
+      rb_raise(rb_eSyntaxError, "SyntaxError: nm_complex64 does not support this operator.");
+      // double complex rha = CMPLXF(NUM2DBL(rb_funcall(another, rb_intern("real"), 0, Qnil)), NUM2DBL(rb_funcall(another, rb_intern("imaginary"), 0, Qnil)));
+      // double complex* left_elements = (double complex*)left->elements;
+
+      // for(size_t index = 0; index < left->count; index++){
+      //   result_elements[index] = ((left_elements[index] > rha) ? true : false);
+      // }
       break;
     }
   }
@@ -1231,6 +1331,33 @@ VALUE nm_gteq(VALUE self, VALUE another){
   bool* result_elements = ALLOC_N(bool, result->shape[0] * result->shape[1]);
 
   switch (left->dtype) {
+    case nm_bool: {
+      double rha = NUM2DBL(another);
+      bool* left_elements = (bool*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] >= rha) ? true : false);
+      }
+      break;
+    }
+    case nm_int: {
+      double rha = NUM2DBL(another);
+      int* left_elements = (int*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] >= rha) ? true : false);
+      }
+      break;
+    }
+    case nm_float32: {
+      double rha = NUM2DBL(another);
+      float* left_elements = (float*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] >= rha) ? true : false);
+      }
+      break;
+    }
     case nm_float64: {
       double rha = NUM2DBL(another);
       double* left_elements = (double*)left->elements;
@@ -1238,6 +1365,26 @@ VALUE nm_gteq(VALUE self, VALUE another){
       for(size_t index = 0; index < left->count; index++){
         result_elements[index] = ((left_elements[index] >= rha) ? true : false);
       }
+      break;
+    }
+    case nm_complex32: {
+      rb_raise(rb_eSyntaxError, "SyntaxError: nm_complex32 does not support this operator.");
+      // float complex rha = CMPLXF(NUM2DBL(rb_funcall(another, rb_intern("real"), 0, Qnil)), NUM2DBL(rb_funcall(another, rb_intern("imaginary"), 0, Qnil)));;
+      // float complex* left_elements = (float complex*)left->elements;
+
+      // for(size_t index = 0; index < left->count; index++){
+      //   result_elements[index] = ((left_elements[index] >= rha) ? true : false);
+      // }
+      break;
+    }
+    case nm_complex64: {
+      rb_raise(rb_eSyntaxError, "SyntaxError: nm_complex64 does not support this operator.");
+      // double complex rha = CMPLXF(NUM2DBL(rb_funcall(another, rb_intern("real"), 0, Qnil)), NUM2DBL(rb_funcall(another, rb_intern("imaginary"), 0, Qnil)));
+      // double complex* left_elements = (double complex*)left->elements;
+
+      // for(size_t index = 0; index < left->count; index++){
+      //   result_elements[index] = ((left_elements[index] >= rha) ? true : false);
+      // }
       break;
     }
   }
@@ -1268,6 +1415,33 @@ VALUE nm_lt(VALUE self, VALUE another){
   bool* result_elements = ALLOC_N(bool, result->shape[0] * result->shape[1]);
 
   switch (left->dtype) {
+    case nm_bool: {
+      double rha = NUM2DBL(another);
+      bool* left_elements = (bool*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] < rha) ? true : false);
+      }
+      break;
+    }
+    case nm_int: {
+      double rha = NUM2DBL(another);
+      int* left_elements = (int*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] < rha) ? true : false);
+      }
+      break;
+    }
+    case nm_float32: {
+      double rha = NUM2DBL(another);
+      float* left_elements = (float*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] < rha) ? true : false);
+      }
+      break;
+    }
     case nm_float64: {
       double rha = NUM2DBL(another);
       double* left_elements = (double*)left->elements;
@@ -1275,6 +1449,26 @@ VALUE nm_lt(VALUE self, VALUE another){
       for(size_t index = 0; index < left->count; index++){
         result_elements[index] = ((left_elements[index] < rha) ? true : false);
       }
+      break;
+    }
+    case nm_complex32: {
+      rb_raise(rb_eSyntaxError, "SyntaxError: nm_complex32 does not support this operator.");
+      // float complex rha = CMPLXF(NUM2DBL(rb_funcall(another, rb_intern("real"), 0, Qnil)), NUM2DBL(rb_funcall(another, rb_intern("imaginary"), 0, Qnil)));;
+      // float complex* left_elements = (float complex*)left->elements;
+
+      // for(size_t index = 0; index < left->count; index++){
+      //   result_elements[index] = ((left_elements[index] < rha) ? true : false);
+      // }
+      break;
+    }
+    case nm_complex64: {
+      rb_raise(rb_eSyntaxError, "SyntaxError: nm_complex64 does not support this operator.");
+      // double complex rha = CMPLXF(NUM2DBL(rb_funcall(another, rb_intern("real"), 0, Qnil)), NUM2DBL(rb_funcall(another, rb_intern("imaginary"), 0, Qnil)));
+      // double complex* left_elements = (double complex*)left->elements;
+
+      // for(size_t index = 0; index < left->count; index++){
+      //   result_elements[index] = ((left_elements[index] < rha) ? true : false);
+      // }
       break;
     }
   }
@@ -1306,6 +1500,33 @@ VALUE nm_lteq(VALUE self, VALUE another){
   bool* result_elements = ALLOC_N(bool, result->shape[0] * result->shape[1]);
 
   switch (left->dtype) {
+    case nm_bool: {
+      double rha = NUM2DBL(another);
+      bool* left_elements = (bool*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] <= rha) ? true : false);
+      }
+      break;
+    }
+    case nm_int: {
+      double rha = NUM2DBL(another);
+      int* left_elements = (int*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] <= rha) ? true : false);
+      }
+      break;
+    }
+    case nm_float32: {
+      double rha = NUM2DBL(another);
+      float* left_elements = (float*)left->elements;
+
+      for(size_t index = 0; index < left->count; index++){
+        result_elements[index] = (((double)left_elements[index] <= rha) ? true : false);
+      }
+      break;
+    }
     case nm_float64: {
       double rha = NUM2DBL(another);
       double* left_elements = (double*)left->elements;
@@ -1313,6 +1534,26 @@ VALUE nm_lteq(VALUE self, VALUE another){
       for(size_t index = 0; index < left->count; index++){
         result_elements[index] = ((left_elements[index] <= rha) ? true : false);
       }
+      break;
+    }
+    case nm_complex32: {
+      rb_raise(rb_eSyntaxError, "SyntaxError: nm_complex32 does not support this operator.");
+      // float complex rha = CMPLXF(NUM2DBL(rb_funcall(another, rb_intern("real"), 0, Qnil)), NUM2DBL(rb_funcall(another, rb_intern("imaginary"), 0, Qnil)));;
+      // float complex* left_elements = (float complex*)left->elements;
+
+      // for(size_t index = 0; index < left->count; index++){
+      //   result_elements[index] = ((left_elements[index] <= rha) ? true : false);
+      // }
+      break;
+    }
+    case nm_complex64: {
+      rb_raise(rb_eSyntaxError, "SyntaxError: nm_complex64 does not support this operator.");
+      // double complex rha = CMPLXF(NUM2DBL(rb_funcall(another, rb_intern("real"), 0, Qnil)), NUM2DBL(rb_funcall(another, rb_intern("imaginary"), 0, Qnil)));
+      // double complex* left_elements = (double complex*)left->elements;
+
+      // for(size_t index = 0; index < left->count; index++){
+      //   result_elements[index] = ((left_elements[index] <= rha) ? true : false);
+      // }
       break;
     }
   }

--- a/ext/ruby_nmatrix.c
+++ b/ext/ruby_nmatrix.c
@@ -284,18 +284,18 @@ VALUE nm_sparse_to_array(VALUE self);
  */
 VALUE nm_sparse_to_nmatrix(VALUE self);
 
-void get_dense_from_coo(const double* data, const size_t rows,
+void get_dense_from_coo(const void* data_t, const size_t rows,
                        const size_t cols, const size_t* ia,
-                       const size_t* ja, double* elements);
-void get_dense_from_csc(const double* data, const size_t rows,
+                       const size_t* ja, void* elements_t, nm_dtype);
+void get_dense_from_csc(const void* data_t, const size_t rows,
                        const size_t cols, const size_t* ia,
-                       const size_t* ja, double* elements);
-void get_dense_from_csr(const double* data, const size_t rows,
+                       const size_t* ja, void* elements_t, nm_dtype);
+void get_dense_from_csr(const void* data_t, const size_t rows,
                        const size_t cols, const size_t* ia,
-                       const size_t* ja, double* elements);
-void get_dense_from_dia(const double* data, const size_t rows,
+                       const size_t* ja, void* elements_t, nm_dtype);
+void get_dense_from_dia(const void* data_t, const size_t rows,
                        const size_t cols, const size_t* offset,
-                       double* elements);
+                       void* elements_t, nm_dtype);
 
 void Init_nmatrix() {
 


### PR DESCRIPTION
Fixed compiler warnings for sparse.c. Also, fixed a switch statement typo.

To prevent the nesting of switch(input->sptype) and switch(input->dtype), I passed the input->dtype to get_dense_from_* functions.

Will also fix compiler warnings for remaining files.