### PR TITLE
OSX: Fix for not symlinked openblas and lapack

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -22,6 +22,8 @@ HEADER_DIRS = [
   '/usr/local/include',
   INCLUDEDIR,
   '/usr/include',
+  '/usr/local/opt/openblas/include',
+  '/usr/local/opt/lapack/include',
 ]
 
 LIB_DIRS = [
@@ -29,6 +31,8 @@ LIB_DIRS = [
   '/usr/local/lib',
   LIBDIR,
   '/usr/lib',
+  '/usr/local/opt/openblas/lib',
+  '/usr/local/opt/lapack/lib',
 ]
 
 dir_config(extension_name, HEADER_DIRS, LIB_DIRS)


### PR DESCRIPTION
This fixes linking step during compilation in OSX.