### PR TITLE
add serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # compiled output
 /tmp
-Gemfile.lock
 /.yardoc
 .rake_tasks~
 *.so

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,56 @@
+PATH
+  remote: .
+  specs:
+    numruby (0.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.1)
+    coderay (1.1.3)
+    json (2.5.1)
+    method_source (1.0.0)
+    minitest (5.14.3)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rainbow (3.0.0)
+    rake (13.0.3)
+    rake-compiler (0.9.9)
+      rake
+    rdoc (4.3.0)
+    regexp_parser (2.0.3)
+    rexml (3.2.4)
+    rubocop (1.8.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.0)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  bundler (>= 1.6)
+  json (>= 1.5.5)
+  minitest (~> 5.0)
+  numruby!
+  pry (~> 0.10)
+  rake (>= 10.3)
+  rake-compiler (~> 0.8)
+  rdoc (~> 4.0, >= 4.0.1)
+  rubocop (>= 0.49.0)
+
+BUNDLED WITH
+   2.2.6

--- a/lib/numruby/nmatrix.rb
+++ b/lib/numruby/nmatrix.rb
@@ -89,6 +89,46 @@ class NMatrix
     return self.elements
   end
 
+  def _dump data
+    [
+      self.dim,
+      self.dtype,
+      self.stype,
+      self.shape,
+      self.elements,
+    ].join(":")
+  end
+
+  def self._load serial
+    data = serial.split(":")
+    dim = data[0].to_i
+    dtype = data[1].to_sym
+    stype = data[2].to_sym
+    shape = data[3..(3+dim-1)]
+    elements = data[(3+dim)..data.length-1]
+    parsed_elements = []
+    
+    if dtype == :nm_bool 
+      elements.each do |e|
+        parsed_elements.push(e == "true" ? true : false)
+      end
+    elsif dtype == :nm_float64
+      elements.each do |e|
+        parsed_elements.push(e.to_f)
+      end
+    else 
+      # Convert to Integer
+      elements.each do |e|
+        parsed_elements.push(e.to_i)
+      end
+    end
+    parsed_shape = []
+    shape.each do |e| 
+      parsed_shape.push(e.to_i)
+    end
+    self.new(parsed_shape, parsed_elements, dtype)
+  end
+
   def inspect #:nodoc:
     original_inspect = super()
     original_inspect = original_inspect[0...original_inspect.size-1]

--- a/test/nmatrix_test.rb
+++ b/test/nmatrix_test.rb
@@ -60,4 +60,16 @@ class NMatrix::CreationTest < Minitest::Test
     assert_equal @m_int[0, 0..1, 0..1], @s_int
   end
 
+  def test_serializing
+    serialized_data_float = Marshal.dump(@m)
+    deserialized_data_float = Marshal.load(serialized_data_float)
+    serialized_data_int = Marshal.dump(@m_int)
+    deserialized_data_int = Marshal.load(serialized_data_int)
+    serialized_data_bool = Marshal.dump(@b)
+    deserialized_data_bool = Marshal.load(serialized_data_bool)
+    assert_equal @m, deserialized_data_float
+    assert_equal @m_int, deserialized_data_int
+    assert_equal @b, deserialized_data_bool
+  end
+  
 end


### PR DESCRIPTION
### Description
Added serialization for NMatrix class using Marshal module and custom implementation of load and dump functions.
Default Marshal serialization methods threw error so We needed to create our own serialization/deserialization strategies.
nm_int is the default fallback for dtype if it's not nm_float64 or nm_bool

Closes #35

(Explain how this PR changes numruby.)
This PR adds the ability for NMatrix to serialize the class objects which can be used to store the data in a file for future and to pass it between different processes and to be utilized

## Test Plan
the test is written for comparing the original object and the one after serialization and deserialization
it checks for nm_float64, nm_int, and nm_bool dtypes 