### PR TITLE
RubyGrant 2020 related work

### DIFF
--- a/ext/accessors.c
+++ b/ext/accessors.c
@@ -3,7 +3,7 @@
  */
 VALUE nm_accessor_get(int argc, VALUE* argv, VALUE self){
   nmatrix* nmat;
-  Data_Get_Struct(self, nmatrix, nmat);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, nmat);
 
   size_t* lower_indices = ALLOC_N(size_t, nmat->ndims);
   size_t* upper_indices = ALLOC_N(size_t, nmat->ndims);
@@ -24,7 +24,7 @@ VALUE nm_accessor_get(int argc, VALUE* argv, VALUE self){
 
             get_slice(nmat, lower_indices, upper_indices, slice);
 
-            return Data_Wrap_Struct(NMatrix, NULL, nm_free, slice);
+            return TypedData_Wrap_Struct(NMatrix, &nm_data_type, slice);
 
             //return a slice
           }
@@ -48,7 +48,7 @@ VALUE nm_accessor_get(int argc, VALUE* argv, VALUE self){
 
             get_slice(nmat, lower_indices, upper_indices, slice);
 
-            return Data_Wrap_Struct(NMatrix, NULL, nm_free, slice);
+            return TypedData_Wrap_Struct(NMatrix, &nm_data_type, slice);
 
             //return a slice
           }
@@ -72,7 +72,7 @@ VALUE nm_accessor_get(int argc, VALUE* argv, VALUE self){
 
             get_slice(nmat, lower_indices, upper_indices, slice);
 
-            return Data_Wrap_Struct(NMatrix, NULL, nm_free, slice);
+            return TypedData_Wrap_Struct(NMatrix, &nm_data_type, slice);
 
             //return a slice
           }
@@ -96,7 +96,7 @@ VALUE nm_accessor_get(int argc, VALUE* argv, VALUE self){
 
             get_slice(nmat, lower_indices, upper_indices, slice);
 
-            return Data_Wrap_Struct(NMatrix, NULL, nm_free, slice);
+            return TypedData_Wrap_Struct(NMatrix, &nm_data_type, slice);
 
             //return a slice
           }
@@ -120,7 +120,7 @@ VALUE nm_accessor_get(int argc, VALUE* argv, VALUE self){
 
             get_slice(nmat, lower_indices, upper_indices, slice);
 
-            return Data_Wrap_Struct(NMatrix, NULL, nm_free, slice);
+            return TypedData_Wrap_Struct(NMatrix, &nm_data_type, slice);
 
             //return a slice
           }
@@ -144,7 +144,7 @@ VALUE nm_accessor_get(int argc, VALUE* argv, VALUE self){
 
             get_slice(nmat, lower_indices, upper_indices, slice);
 
-            return Data_Wrap_Struct(NMatrix, NULL, nm_free, slice);
+            return TypedData_Wrap_Struct(NMatrix, &nm_data_type, slice);
 
             //return a slice
           }
@@ -193,7 +193,7 @@ VALUE nm_accessor_get(int argc, VALUE* argv, VALUE self){
  */
 VALUE nm_accessor_set(int argc, VALUE* argv, VALUE self){
   nmatrix* nmat;
-  Data_Get_Struct(self, nmatrix, nmat);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, nmat);
 
   size_t index = get_index(nmat, argv);
 

--- a/ext/accessors.c
+++ b/ext/accessors.c
@@ -66,13 +66,13 @@ VALUE nm_accessor_get(int argc, VALUE* argv, VALUE self){
         {
           if(is_slice(nmat, argv)){
 
-            nmatrix* slice = ALLOC(nmatrix);
+            nmatrix_buffer* slice = ALLOC(nmatrix_buffer);
             slice->dtype = nmat->dtype;
-            slice->stype = nmat->stype;
+            slice->mat = nmat;
 
             get_slice(nmat, lower_indices, upper_indices, slice);
 
-            return TypedData_Wrap_Struct(NMatrix, &nm_data_type, slice);
+            return TypedData_Wrap_Struct(NMatrix, &nm_buffer_data_type, slice);
 
             //return a slice
           }

--- a/ext/blas.c
+++ b/ext/blas.c
@@ -9,8 +9,8 @@
 VALUE nm_dot(VALUE self, VALUE another){
   nmatrix* left;
   nmatrix* right;
-  Data_Get_Struct(self, nmatrix, left);
-  Data_Get_Struct(another, nmatrix, right);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, left);
+  TypedData_Get_Struct(another, nmatrix, &nm_data_type, right);
 
   nmatrix* result = ALLOC(nmatrix);
   result->dtype = left->dtype;
@@ -67,7 +67,7 @@ VALUE nm_dot(VALUE self, VALUE another){
     }
   }
 
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }
 
 /*
@@ -79,7 +79,7 @@ VALUE nm_dot(VALUE self, VALUE another){
  */
 VALUE nm_norm2(VALUE self){
   nmatrix* matrix;
-  Data_Get_Struct(self, nmatrix, matrix);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, matrix);
   //check mat is vector
   VALUE val = Qnil;
 

--- a/ext/broadcasting.c
+++ b/ext/broadcasting.c
@@ -331,7 +331,7 @@ void broadcast_matrices(nmatrix* nmat1, nmatrix* nmat2) {
  */
 VALUE nm_broadcast_to(int argc, VALUE* argv) {
   nmatrix* nmat;
-  Data_Get_Struct(argv[0], nmatrix, nmat);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, nmat);
 
   size_t new_ndims = (size_t)RARRAY_LEN(argv[1]);
 
@@ -342,7 +342,7 @@ VALUE nm_broadcast_to(int argc, VALUE* argv) {
 
   broadcast_matrix(nmat, new_shape, new_ndims);
 
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, nmat);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, nmat);
 }
 
 /*

--- a/ext/comparison.c
+++ b/ext/comparison.c
@@ -6,8 +6,8 @@
 VALUE nm_eqeq(VALUE self, VALUE another){
   nmatrix* left;
   nmatrix* right;
-  Data_Get_Struct(self, nmatrix, left);
-  Data_Get_Struct(another, nmatrix, right);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, left);
+  TypedData_Get_Struct(another, nmatrix, &nm_data_type, right);
 
   if(left->count != right->count){
     return Qfalse;
@@ -99,7 +99,7 @@ VALUE nm_eqeq(VALUE self, VALUE another){
  */
 VALUE nm_gt(VALUE self, VALUE another){
   nmatrix* left;
-  Data_Get_Struct(self, nmatrix, left);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, left);
 
   nmatrix* result = ALLOC(nmatrix);
   result->dtype = nm_bool;
@@ -172,7 +172,7 @@ VALUE nm_gt(VALUE self, VALUE another){
     }
   }
   result->elements = result_elements;
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }
 
 /*
@@ -183,7 +183,7 @@ VALUE nm_gt(VALUE self, VALUE another){
  */
 VALUE nm_gteq(VALUE self, VALUE another){
   nmatrix* left;
-  Data_Get_Struct(self, nmatrix, left);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, left);
 
   nmatrix* result = ALLOC(nmatrix);
   result->dtype = nm_bool;
@@ -256,7 +256,7 @@ VALUE nm_gteq(VALUE self, VALUE another){
     }
   }
   result->elements = result_elements;
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }
 
 /*
@@ -267,7 +267,7 @@ VALUE nm_gteq(VALUE self, VALUE another){
  */
 VALUE nm_lt(VALUE self, VALUE another){
   nmatrix* left;
-  Data_Get_Struct(self, nmatrix, left);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, left);
 
   nmatrix* result = ALLOC(nmatrix);
   result->dtype = nm_bool;
@@ -340,7 +340,7 @@ VALUE nm_lt(VALUE self, VALUE another){
     }
   }
   result->elements = result_elements;
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }
 
 
@@ -352,7 +352,7 @@ VALUE nm_lt(VALUE self, VALUE another){
  */
 VALUE nm_lteq(VALUE self, VALUE another){
   nmatrix* left;
-  Data_Get_Struct(self, nmatrix, left);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, left);
 
   nmatrix* result = ALLOC(nmatrix);
   result->dtype = nm_bool;
@@ -425,5 +425,5 @@ VALUE nm_lteq(VALUE self, VALUE another){
     }
   }
   result->elements = result_elements;
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }

--- a/ext/elementwise.c
+++ b/ext/elementwise.c
@@ -44,7 +44,7 @@ VALUE nm_##name(VALUE self, VALUE another){        \
     case nm_bool:                                                                 \
     {                                                                            \
       bool* result_elements = ALLOC_N(bool, result->count);                  \
-      if(RB_TYPE_P(another, T_TRUE) || RB_TYPE_P(another, T_FALSE)){           \
+      if(rb_obj_is_kind_of(another, NMatrix) == Qfalse){           \
         bool* left_elements = (bool*)left->elements;                       \
         for(size_t index = 0; index < left->count; index++){                     \
           result_elements[index] = (left_elements[index]) oper (another ? Qtrue : Qfalse);      \
@@ -64,7 +64,7 @@ VALUE nm_##name(VALUE self, VALUE another){        \
     case nm_int:                                                                 \
     {                                                                            \
       int* result_elements = ALLOC_N(int, result->count);                  \
-      if(RB_TYPE_P(another, T_FLOAT) || RB_TYPE_P(another, T_FIXNUM)){           \
+      if(rb_obj_is_kind_of(another, NMatrix) == Qfalse){           \
         int* left_elements = (int*)left->elements;                               \
         for(size_t index = 0; index < left->count; index++){                     \
           result_elements[index] = (left_elements[index]) oper (NUM2DBL(another));      \
@@ -84,7 +84,7 @@ VALUE nm_##name(VALUE self, VALUE another){        \
     case nm_float32:                                                             \
     {                                                                            \
       float* result_elements = ALLOC_N(float, result->count);                    \
-      if(RB_TYPE_P(another, T_FLOAT) || RB_TYPE_P(another, T_FIXNUM)){           \
+      if(rb_obj_is_kind_of(another, NMatrix) == Qfalse){           \
         float* left_elements = (float*)left->elements;                           \
         for(size_t index = 0; index < left->count; index++){                     \
           result_elements[index] = (left_elements[index]) oper (NUM2DBL(another));      \
@@ -104,7 +104,7 @@ VALUE nm_##name(VALUE self, VALUE another){        \
     case nm_float64:                                                             \
     {                                                                            \
       double* result_elements = ALLOC_N(double, result->count);                  \
-      if(RB_TYPE_P(another, T_FLOAT) || RB_TYPE_P(another, T_FIXNUM)){           \
+      if(rb_obj_is_kind_of(another, NMatrix) == Qfalse){           \
         double* left_elements = (double*)left->elements;                    \
         for(size_t index = 0; index < left->count; index++){                     \
           result_elements[index] = (left_elements[index]) oper (NUM2DBL(another));      \
@@ -124,7 +124,7 @@ VALUE nm_##name(VALUE self, VALUE another){        \
     case nm_complex32:                                                             \
     {                                                                            \
       complex float* result_elements = ALLOC_N(complex float, result->count);                    \
-      if(RB_TYPE_P(another, T_FLOAT) || RB_TYPE_P(another, T_FIXNUM)){           \
+      if(rb_obj_is_kind_of(another, NMatrix) == Qfalse){           \
         complex float* left_elements = (complex float*)left->elements;      \
         for(size_t index = 0; index < left->count; index++){                     \
           result_elements[index] = (left_elements[index]) oper (NUM2DBL(another));      \
@@ -144,7 +144,7 @@ VALUE nm_##name(VALUE self, VALUE another){        \
     case nm_complex64:                                                             \
     {                                                                            \
       complex double* result_elements = ALLOC_N(complex double, result->count);                    \
-      if(RB_TYPE_P(another, T_FLOAT) || RB_TYPE_P(another, T_FIXNUM)){           \
+      if(rb_obj_is_kind_of(another, NMatrix) == Qfalse){           \
         complex double* left_elements = (complex double*)left->elements;    \
         for(size_t index = 0; index < left->count; index++){                     \
           result_elements[index] = (left_elements[index]) oper (NUM2DBL(another));      \
@@ -161,6 +161,26 @@ VALUE nm_##name(VALUE self, VALUE another){        \
       result->elements = result_elements;                                          \
       break;                                                                       \
     }                                                                              \
+    default:                                                                    \
+    {                                                                            \
+      double* result_elements = ALLOC_N(double, result->count);                  \
+      if(rb_obj_is_kind_of(another, NMatrix) == Qfalse){           \
+        double* left_elements = (double*)left->elements;                    \
+        for(size_t index = 0; index < left->count; index++){                     \
+          result_elements[index] = (left_elements[index]) oper (NUM2DBL(another));      \
+        }                                                                        \
+      }                                                                          \
+      else{                                                                      \
+        double* left_elements = (double*)left_copy->elements;                    \
+        double* right_elements = (double*)right_copy->elements;                       \
+                                                                                 \
+        for(size_t index = 0; index < left_copy->count; index++){                     \
+          result_elements[index] = (left_elements[index]) oper (right_elements[index]); \
+        }                                                                        \
+      }                                                                          \
+      result->elements = result_elements;                                        \
+      break;                                                                     \
+    }                                                                            \
   }                                                                                 \
   return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);                         \
 }

--- a/ext/elementwise.c
+++ b/ext/elementwise.c
@@ -7,7 +7,7 @@
 #define DEF_ELEMENTWISE_RUBY_ACCESSOR(name, oper)  \
 VALUE nm_##name(VALUE self, VALUE another){        \
   nmatrix* left;                                   \
-  Data_Get_Struct(self, nmatrix, left);            \
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, left);            \
                                                    \
   nmatrix* right;                                  \
   nmatrix* result = ALLOC(nmatrix);                \
@@ -15,7 +15,7 @@ VALUE nm_##name(VALUE self, VALUE another){        \
   nmatrix* left_copy;                              \
   nmatrix* right_copy;                             \
   if(rb_obj_is_kind_of(another, NMatrix) == Qtrue) {\
-    Data_Get_Struct(another, nmatrix, right);       \
+    TypedData_Get_Struct(another, nmatrix, &nm_data_type, right);       \
     left_copy = matrix_copy(left);                  \
     right_copy = matrix_copy(right);                \
     broadcast_matrices(left_copy, right_copy);      \
@@ -182,7 +182,7 @@ VALUE nm_##name(VALUE self, VALUE another){        \
       break;                                                                     \
     }                                                                            \
   }                                                                                 \
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);                         \
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);                         \
 }
 
 DEF_ELEMENTWISE_RUBY_ACCESSOR(add, +)
@@ -200,7 +200,7 @@ DEF_ELEMENTWISE_RUBY_ACCESSOR(divide, /)
 
 VALUE nm_sin(VALUE self){
   nmatrix* input;
-  Data_Get_Struct(self, nmatrix, input);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, input);
 
   nmatrix* result = ALLOC(nmatrix);
   result->dtype = input->dtype;
@@ -276,13 +276,13 @@ VALUE nm_sin(VALUE self){
     }
   }
 
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }
 
 #define DEF_UNARY_RUBY_ACCESSOR(oper, name)                        \
 static VALUE nm_##name(VALUE self) {                               \
   nmatrix* input;                                                  \
-  Data_Get_Struct(self, nmatrix, input);                           \
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, input);                           \
                                                                    \
   nmatrix* result = ALLOC(nmatrix);                                \
   result->dtype = input->dtype;                                    \
@@ -356,7 +356,7 @@ static VALUE nm_##name(VALUE self) {                               \
       break;                                                       \
     }                                                              \
   }                                                                \
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);         \
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);         \
 }
 
 DEF_UNARY_RUBY_ACCESSOR(cos, cos)
@@ -377,7 +377,7 @@ DEF_UNARY_RUBY_ACCESSOR(sqrt, sqrt)
 #define DEF_UNARY_RUBY_ACCESSOR_NON_COMPLEX(oper, name)            \
 static VALUE nm_##name(VALUE self) {                               \
   nmatrix* input;                                                  \
-  Data_Get_Struct(self, nmatrix, input);                           \
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, input);                           \
                                                                    \
   nmatrix* result = ALLOC(nmatrix);                                \
   result->dtype = input->dtype;                                    \
@@ -439,7 +439,7 @@ static VALUE nm_##name(VALUE self) {                               \
       /* Not supported message */                                  \
     }                                                              \
   }                                                                \
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);         \
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);         \
 }
 
 DEF_UNARY_RUBY_ACCESSOR_NON_COMPLEX(log2, log2)

--- a/ext/iteration.c
+++ b/ext/iteration.c
@@ -1,6 +1,6 @@
 VALUE nm_each(VALUE self) {
   nmatrix* input;
-  Data_Get_Struct(self, nmatrix, input);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, input);
 
   switch(input->stype){
     case nm_dense:
@@ -78,7 +78,7 @@ VALUE nm_each(VALUE self) {
 
 VALUE nm_each_with_indices(VALUE self) {
   nmatrix* input;
-  Data_Get_Struct(self, nmatrix, input);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, input);
 
   VALUE* shape_array = ALLOC_N(VALUE, input->ndims);
   for (size_t index = 0; index < input->ndims; index++){
@@ -217,7 +217,7 @@ VALUE nm_map_stored(VALUE self) {
 
 VALUE nm_each_rank(VALUE self, VALUE dimension_idx) {
   nmatrix* input;
-  Data_Get_Struct(self, nmatrix, input);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, input);
 
   size_t dim_idx = NUM2SIZET(dimension_idx);
 
@@ -249,7 +249,7 @@ VALUE nm_each_rank(VALUE self, VALUE dimension_idx) {
 
     get_slice(input, lower_indices, upper_indices, result);
 
-    rb_yield(Data_Wrap_Struct(NMatrix, NULL, nm_free, result));
+    rb_yield(TypedData_Wrap_Struct(NMatrix, &nm_data_type, result));
   }
 
   return self;

--- a/ext/lapack.c
+++ b/ext/lapack.c
@@ -1287,7 +1287,6 @@ VALUE nm_det(VALUE self){
   switch (matrix->dtype) {
     case nm_float32:
     {
-      
       float* elements = ALLOC_N(float, matrix->count);
       int* pivot = ALLOC_N(int, min(m,n)+1);
     
@@ -1309,7 +1308,27 @@ VALUE nm_det(VALUE self){
     }
     case nm_float64:
     {
-
+      double* elements = ALLOC_N(double, matrix->count);
+      int* pivot = ALLOC_N(int, min(m,n)+1);
+    
+      dgetrf(matrix->elements, matrix->shape[1], matrix->shape[0], pivot, elements);
+    
+      int num_perm = 0;
+      int j = 0;
+      for(int i = 0; i < min(m,n)+1; ++i){
+        if(pivot[i]-1 != j){num_perm += 1;}
+        j++;
+      }
+    
+      prod = (num_perm % 2 == 1) ? 1 : -1;
+    
+      for(int i =0; i < min(m,n); i++){
+        prod *= elements[matrix->shape[0]*i + i];
+      }
+      break;
+    }
+    default:
+    {
       double* elements = ALLOC_N(double, matrix->count);
       int* pivot = ALLOC_N(int, min(m,n)+1);
     

--- a/ext/lapack.c
+++ b/ext/lapack.c
@@ -5,7 +5,7 @@
  */
 VALUE nm_geqrf(int argc, VALUE* argv) {
   nmatrix* matrix;
-  Data_Get_Struct(argv[0], nmatrix, matrix);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix);
 
   int m = matrix->shape[0]; //no. of rows
   int n = matrix->shape[1]; //no. of cols
@@ -36,8 +36,8 @@ VALUE nm_geqrf(int argc, VALUE* argv) {
       result_qr->elements = elements;
       result_tau->elements = tau_elements;
 
-      VALUE qr = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_qr);
-      VALUE tau = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_tau);
+      VALUE qr = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_qr);
+      VALUE tau = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_tau);
       return rb_ary_new3(2, qr, tau);
       break;
     }
@@ -51,8 +51,8 @@ VALUE nm_geqrf(int argc, VALUE* argv) {
       result_qr->elements = elements;
       result_tau->elements = tau_elements;
 
-      VALUE qr = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_qr);
-      VALUE tau = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_tau);
+      VALUE qr = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_qr);
+      VALUE tau = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_tau);
       return rb_ary_new3(2, qr, tau);
       break;
     }
@@ -66,8 +66,8 @@ VALUE nm_geqrf(int argc, VALUE* argv) {
       result_qr->elements = elements;
       result_tau->elements = tau_elements;
 
-      VALUE qr = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_qr);
-      VALUE tau = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_tau);
+      VALUE qr = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_qr);
+      VALUE tau = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_tau);
       return rb_ary_new3(2, qr, tau);
       break;
     }
@@ -81,8 +81,8 @@ VALUE nm_geqrf(int argc, VALUE* argv) {
       result_qr->elements = elements;
       result_tau->elements = tau_elements;
 
-      VALUE qr = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_qr);
-      VALUE tau = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_tau);
+      VALUE qr = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_qr);
+      VALUE tau = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_tau);
       return rb_ary_new3(2, qr, tau);
       break;
     }
@@ -99,10 +99,10 @@ VALUE nm_geqrf(int argc, VALUE* argv) {
  */
 VALUE nm_orgqr(int argc, VALUE* argv) {
   nmatrix* matrix_qr;
-  Data_Get_Struct(argv[0], nmatrix, matrix_qr);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix_qr);
 
   nmatrix* matrix_tau;
-  Data_Get_Struct(argv[1], nmatrix, matrix_tau);
+  TypedData_Get_Struct(argv[1], nmatrix, &nm_data_type, matrix_tau);
 
   int m = matrix_qr->shape[0]; //no. of rows
   int n = matrix_qr->shape[1]; //no. of cols
@@ -131,7 +131,7 @@ VALUE nm_orgqr(int argc, VALUE* argv) {
 
       result_q->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result_q);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_q);
       break;
     }
     case nm_float64:
@@ -143,7 +143,7 @@ VALUE nm_orgqr(int argc, VALUE* argv) {
 
       result_q->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result_q);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_q);
       break;
     }
     case nm_complex32:
@@ -155,7 +155,7 @@ VALUE nm_orgqr(int argc, VALUE* argv) {
 
       result_q->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result_q);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_q);
       break;
     }
     case nm_complex64:
@@ -167,7 +167,7 @@ VALUE nm_orgqr(int argc, VALUE* argv) {
 
       result_q->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result_q);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_q);
       break;
     }
   }
@@ -181,7 +181,7 @@ VALUE nm_orgqr(int argc, VALUE* argv) {
  */
 VALUE nm_geqp3(int argc, VALUE* argv) {
   nmatrix* matrix;
-  Data_Get_Struct(argv[0], nmatrix, matrix);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix);
 
   int m = matrix->shape[0]; //no. of rows
   int n = matrix->shape[1]; //no. of cols
@@ -216,9 +216,9 @@ VALUE nm_geqp3(int argc, VALUE* argv) {
       result_tau->elements = tau_elements;
       result_jpvt->elements = jpvt_elements;
 
-      VALUE qr = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_qr);
-      VALUE tau = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_tau);
-      VALUE jpvt = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_jpvt);
+      VALUE qr = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_qr);
+      VALUE tau = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_tau);
+      VALUE jpvt = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_jpvt);
       return rb_ary_new3(3, qr, tau, jpvt);
       break;
     }
@@ -234,9 +234,9 @@ VALUE nm_geqp3(int argc, VALUE* argv) {
       result_tau->elements = tau_elements;
       result_jpvt->elements = jpvt_elements;
 
-      VALUE qr = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_qr);
-      VALUE tau = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_tau);
-      VALUE jpvt = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_jpvt);
+      VALUE qr = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_qr);
+      VALUE tau = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_tau);
+      VALUE jpvt = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_jpvt);
       return rb_ary_new3(3, qr, tau, jpvt);
       break;
     }
@@ -252,9 +252,9 @@ VALUE nm_geqp3(int argc, VALUE* argv) {
       result_tau->elements = tau_elements;
       result_jpvt->elements = jpvt_elements;
 
-      VALUE qr = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_qr);
-      VALUE tau = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_tau);
-      VALUE jpvt = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_jpvt);
+      VALUE qr = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_qr);
+      VALUE tau = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_tau);
+      VALUE jpvt = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_jpvt);
       return rb_ary_new3(3, qr, tau, jpvt);
       break;
     }
@@ -270,9 +270,9 @@ VALUE nm_geqp3(int argc, VALUE* argv) {
       result_tau->elements = tau_elements;
       result_jpvt->elements = jpvt_elements;
 
-      VALUE qr = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_qr);
-      VALUE tau = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_tau);
-      VALUE jpvt = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_jpvt);
+      VALUE qr = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_qr);
+      VALUE tau = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_tau);
+      VALUE jpvt = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_jpvt);
       return rb_ary_new3(3, qr, tau, jpvt);
       break;
     }
@@ -294,7 +294,7 @@ VALUE nm_geqp3(int argc, VALUE* argv) {
  */
 VALUE nm_potrf(int argc, VALUE* argv) {
   nmatrix* matrix;
-  Data_Get_Struct(argv[0], nmatrix, matrix);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix);
 
   bool lower = (bool)RTEST(argv[1]);
 
@@ -324,7 +324,7 @@ VALUE nm_potrf(int argc, VALUE* argv) {
 
       result_cho->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result_cho);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_cho);
       break;
     }
     case nm_float64:
@@ -335,7 +335,7 @@ VALUE nm_potrf(int argc, VALUE* argv) {
 
       result_cho->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result_cho);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_cho);
       break;
     }
     case nm_complex32:
@@ -346,7 +346,7 @@ VALUE nm_potrf(int argc, VALUE* argv) {
 
       result_cho->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result_cho);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_cho);
       break;
     }
     case nm_complex64:
@@ -357,7 +357,7 @@ VALUE nm_potrf(int argc, VALUE* argv) {
 
       result_cho->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result_cho);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_cho);
       break;
     }
   }
@@ -372,14 +372,14 @@ VALUE nm_potrf(int argc, VALUE* argv) {
  */
 VALUE nm_potrs(int argc, VALUE* argv) {
   nmatrix* matrix_a;
-  Data_Get_Struct(argv[0], nmatrix, matrix_a);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix_a);
 
   int m_a = matrix_a->shape[0]; //no. of rows
   int n_a = matrix_a->shape[1]; //no. of cols
   int lda_a = n_a, info = -1;
 
   nmatrix* matrix_b;
-  Data_Get_Struct(argv[1], nmatrix, matrix_b);
+  TypedData_Get_Struct(argv[1], nmatrix, &nm_data_type, matrix_b);
 
   int m_b = matrix_b->shape[0]; //no. of rows
   int n_b = 1; //no. of cols
@@ -410,7 +410,7 @@ VALUE nm_potrs(int argc, VALUE* argv) {
 
       result->elements = elements_b;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
     case nm_float64:
@@ -422,7 +422,7 @@ VALUE nm_potrs(int argc, VALUE* argv) {
 
       result->elements = elements_b;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
     case nm_complex32:
@@ -434,7 +434,7 @@ VALUE nm_potrs(int argc, VALUE* argv) {
 
       result->elements = elements_b;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
     case nm_complex64:
@@ -446,7 +446,7 @@ VALUE nm_potrs(int argc, VALUE* argv) {
 
       result->elements = elements_b;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
   }
@@ -481,7 +481,7 @@ VALUE nm_potrs(int argc, VALUE* argv) {
  */
 VALUE nm_gesdd(int argc, VALUE* argv) {
   nmatrix* matrix;
-  Data_Get_Struct(argv[0], nmatrix, matrix);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix);
 
   int m = matrix->shape[0]; //no. of rows
   int n = matrix->shape[1]; //no. of cols
@@ -552,7 +552,7 @@ VALUE nm_gesdd(int argc, VALUE* argv) {
  */
 VALUE nm_getrf(int argc, VALUE* argv) {
   nmatrix* matrix;
-  Data_Get_Struct(argv[0], nmatrix, matrix);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix);
 
   int m = matrix->shape[0]; //no. of rows
   int n = matrix->shape[1]; //no. of cols
@@ -583,8 +583,8 @@ VALUE nm_getrf(int argc, VALUE* argv) {
       result_lu->elements = elements;
       result_ipiv->elements = ipiv_elements;
 
-      VALUE lu = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_lu);
-      VALUE ipiv = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_ipiv);
+      VALUE lu = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_lu);
+      VALUE ipiv = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_ipiv);
       return rb_ary_new3(2, lu, ipiv);
       break;
     }
@@ -598,8 +598,8 @@ VALUE nm_getrf(int argc, VALUE* argv) {
       result_lu->elements = elements;
       result_ipiv->elements = ipiv_elements;
 
-      VALUE lu = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_lu);
-      VALUE ipiv = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_ipiv);
+      VALUE lu = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_lu);
+      VALUE ipiv = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_ipiv);
       return rb_ary_new3(2, lu, ipiv);
       break;
     }
@@ -613,8 +613,8 @@ VALUE nm_getrf(int argc, VALUE* argv) {
       result_lu->elements = elements;
       result_ipiv->elements = ipiv_elements;
 
-      VALUE lu = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_lu);
-      VALUE ipiv = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_ipiv);
+      VALUE lu = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_lu);
+      VALUE ipiv = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_ipiv);
       return rb_ary_new3(2, lu, ipiv);
       break;
     }
@@ -628,8 +628,8 @@ VALUE nm_getrf(int argc, VALUE* argv) {
       result_lu->elements = elements;
       result_ipiv->elements = ipiv_elements;
 
-      VALUE lu = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_lu);
-      VALUE ipiv = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_ipiv);
+      VALUE lu = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_lu);
+      VALUE ipiv = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_ipiv);
       return rb_ary_new3(2, lu, ipiv);
       break;
     }
@@ -646,17 +646,17 @@ VALUE nm_getrf(int argc, VALUE* argv) {
  */
 VALUE nm_getrs(int argc, VALUE* argv) {
   nmatrix* matrix_a;
-  Data_Get_Struct(argv[0], nmatrix, matrix_a);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix_a);
 
   int m_a = matrix_a->shape[0]; //no. of rows
   int n_a = matrix_a->shape[1]; //no. of cols
   int lda_a = n_a, info = -1;
 
   nmatrix* matrix_ipiv;
-  Data_Get_Struct(argv[1], nmatrix, matrix_ipiv);
+  TypedData_Get_Struct(argv[1], nmatrix, &nm_data_type, matrix_ipiv);
 
   nmatrix* matrix_b;
-  Data_Get_Struct(argv[2], nmatrix, matrix_b);
+  TypedData_Get_Struct(argv[2], nmatrix, &nm_data_type, matrix_b);
 
   int m_b = matrix_b->shape[0]; //no. of rows
   int n_b = 1; //no. of cols
@@ -695,7 +695,7 @@ VALUE nm_getrs(int argc, VALUE* argv) {
 
       result->elements = elements_b;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
     case nm_float64:
@@ -708,7 +708,7 @@ VALUE nm_getrs(int argc, VALUE* argv) {
 
       result->elements = elements_b;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
     case nm_complex32:
@@ -721,7 +721,7 @@ VALUE nm_getrs(int argc, VALUE* argv) {
 
       result->elements = elements_b;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
     case nm_complex64:
@@ -734,7 +734,7 @@ VALUE nm_getrs(int argc, VALUE* argv) {
 
       result->elements = elements_b;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
   }
@@ -751,14 +751,14 @@ VALUE nm_getrs(int argc, VALUE* argv) {
  */
 VALUE nm_getri(int argc, VALUE* argv) {
   nmatrix* matrix_lu;
-  Data_Get_Struct(argv[0], nmatrix, matrix_lu);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix_lu);
 
   int m = matrix_lu->shape[0]; //no. of rows
   int n = matrix_lu->shape[1]; //no. of cols
   int lda = n, info = -1;
 
   nmatrix* matrix_ipiv;
-  Data_Get_Struct(argv[1], nmatrix, matrix_ipiv);
+  TypedData_Get_Struct(argv[1], nmatrix, &nm_data_type, matrix_ipiv);
 
   nmatrix* result = nmatrix_new(matrix_lu->dtype, matrix_lu->stype, 2, matrix_lu->count, matrix_lu->shape, NULL);
 
@@ -782,7 +782,7 @@ VALUE nm_getri(int argc, VALUE* argv) {
 
       result->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
     case nm_float64:
@@ -794,7 +794,7 @@ VALUE nm_getri(int argc, VALUE* argv) {
 
       result->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
     case nm_complex32:
@@ -806,7 +806,7 @@ VALUE nm_getri(int argc, VALUE* argv) {
 
       result->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
     case nm_complex64:
@@ -818,7 +818,7 @@ VALUE nm_getri(int argc, VALUE* argv) {
 
       result->elements = elements;
 
-      return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+      return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
       break;
     }
   }
@@ -865,14 +865,14 @@ VALUE nm_gelss(int argc, VALUE* argv) {
  */
 VALUE nm_posv(int argc, VALUE* argv) {
   nmatrix* matrix_a;
-  Data_Get_Struct(argv[0], nmatrix, matrix_a);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix_a);
 
   int m_a = matrix_a->shape[0]; //no. of rows
   int n_a = matrix_a->shape[1]; //no. of cols
   int lda_a = n_a, info = -1;
 
   nmatrix* matrix_b;
-  Data_Get_Struct(argv[1], nmatrix, matrix_b);
+  TypedData_Get_Struct(argv[1], nmatrix, &nm_data_type, matrix_b);
 
   int m_b = matrix_b->shape[0]; //no. of rows
   int n_b = 1; //no. of cols
@@ -906,8 +906,8 @@ VALUE nm_posv(int argc, VALUE* argv) {
       result_c->elements = elements_a;
       result_x->elements = elements_b;
 
-      VALUE c = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_c);
-      VALUE x = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_x);
+      VALUE c = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_c);
+      VALUE x = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_x);
       return rb_ary_new3(2, c, x);
       break;
     }
@@ -922,8 +922,8 @@ VALUE nm_posv(int argc, VALUE* argv) {
       result_c->elements = elements_a;
       result_x->elements = elements_b;
 
-      VALUE c = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_c);
-      VALUE x = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_x);
+      VALUE c = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_c);
+      VALUE x = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_x);
       return rb_ary_new3(2, c, x);
       break;
     }
@@ -938,8 +938,8 @@ VALUE nm_posv(int argc, VALUE* argv) {
       result_c->elements = elements_a;
       result_x->elements = elements_b;
 
-      VALUE c = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_c);
-      VALUE x = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_x);
+      VALUE c = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_c);
+      VALUE x = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_x);
       return rb_ary_new3(2, c, x);
       break;
     }
@@ -954,8 +954,8 @@ VALUE nm_posv(int argc, VALUE* argv) {
       result_c->elements = elements_a;
       result_x->elements = elements_b;
 
-      VALUE c = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_c);
-      VALUE x = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_x);
+      VALUE c = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_c);
+      VALUE x = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_x);
       return rb_ary_new3(2, c, x);
       break;
     }
@@ -978,14 +978,14 @@ VALUE nm_posv(int argc, VALUE* argv) {
  */
 VALUE nm_gesv(int argc, VALUE* argv) {
   nmatrix* matrix_a;
-  Data_Get_Struct(argv[0], nmatrix, matrix_a);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix_a);
 
   int m_a = matrix_a->shape[0]; //no. of rows
   int n_a = matrix_a->shape[1]; //no. of cols
   int lda_a = n_a, info = -1;
 
   nmatrix* matrix_b;
-  Data_Get_Struct(argv[1], nmatrix, matrix_b);
+  TypedData_Get_Struct(argv[1], nmatrix, &nm_data_type, matrix_b);
 
   int m_b = matrix_b->shape[0]; //no. of rows
   int n_b = matrix_b->shape[1]; //no. of cols
@@ -1020,9 +1020,9 @@ VALUE nm_gesv(int argc, VALUE* argv) {
       result_x->elements = elements_b;
       result_ipiv->elements = ipiv_elements;
 
-      VALUE lu = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_lu);
-      VALUE x = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_x);
-      VALUE ipiv = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_ipiv);
+      VALUE lu = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_lu);
+      VALUE x = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_x);
+      VALUE ipiv = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_ipiv);
       return rb_ary_new3(3, lu, x, ipiv);
       break;
     }
@@ -1039,9 +1039,9 @@ VALUE nm_gesv(int argc, VALUE* argv) {
       result_x->elements = elements_b;
       result_ipiv->elements = ipiv_elements;
 
-      VALUE lu = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_lu);
-      VALUE x = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_x);
-      VALUE ipiv = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_ipiv);
+      VALUE lu = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_lu);
+      VALUE x = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_x);
+      VALUE ipiv = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_ipiv);
       return rb_ary_new3(3, lu, x, ipiv);
       break;
     }
@@ -1058,9 +1058,9 @@ VALUE nm_gesv(int argc, VALUE* argv) {
       result_x->elements = elements_b;
       result_ipiv->elements = ipiv_elements;
 
-      VALUE lu = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_lu);
-      VALUE x = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_x);
-      VALUE ipiv = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_ipiv);
+      VALUE lu = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_lu);
+      VALUE x = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_x);
+      VALUE ipiv = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_ipiv);
       return rb_ary_new3(3, lu, x, ipiv);
       break;
     }
@@ -1077,9 +1077,9 @@ VALUE nm_gesv(int argc, VALUE* argv) {
       result_x->elements = elements_b;
       result_ipiv->elements = ipiv_elements;
 
-      VALUE lu = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_lu);
-      VALUE x = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_x);
-      VALUE ipiv = Data_Wrap_Struct(NMatrix, NULL, nm_free, result_ipiv);
+      VALUE lu = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_lu);
+      VALUE x = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_x);
+      VALUE ipiv = TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_ipiv);
       return rb_ary_new3(3, lu, x, ipiv);
       break;
     }
@@ -1108,7 +1108,7 @@ VALUE nm_gesv(int argc, VALUE* argv) {
  */
 VALUE nm_lange(int argc, VALUE* argv) {
   nmatrix* matrix;
-  Data_Get_Struct(argv[0], nmatrix, matrix);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix);
 
   int m = matrix->shape[0]; //no. of rows
   int n = matrix->shape[1]; //no. of cols
@@ -1167,7 +1167,7 @@ VALUE nm_lange(int argc, VALUE* argv) {
  */
 VALUE nm_invert(VALUE self){
   nmatrix* matrix;
-  Data_Get_Struct(self, nmatrix, matrix);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, matrix);
 
   nmatrix* result = ALLOC(nmatrix);
   result->dtype = matrix->dtype;
@@ -1189,7 +1189,7 @@ VALUE nm_invert(VALUE self){
 
   LAPACKE_dgetri(LAPACK_ROW_MAJOR, n, elements, lda, ipiv);
   result->elements = elements;
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }
 
 void sgetrf(const float* arr, const size_t cols, const size_t rows, int* ipiv, float* arr2) {
@@ -1235,8 +1235,8 @@ void zgetrf(const double complex* arr, const size_t cols, const size_t rows, int
 VALUE nm_solve(VALUE self, VALUE rhs_val){
   nmatrix* lhs;
   nmatrix* rhs;
-  Data_Get_Struct(self, nmatrix, lhs);
-  Data_Get_Struct(rhs_val, nmatrix, rhs);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, lhs);
+  TypedData_Get_Struct(rhs_val, nmatrix, &nm_data_type, rhs);
 
   double* lhs_elements = ALLOC_N(double, lhs->count);
   memcpy(lhs_elements, lhs->elements, sizeof(double)*lhs->count);
@@ -1264,7 +1264,7 @@ VALUE nm_solve(VALUE self, VALUE rhs_val){
 
   result->elements = rhs_elements;
 
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }
 
 
@@ -1277,7 +1277,7 @@ VALUE nm_solve(VALUE self, VALUE rhs_val){
  */
 VALUE nm_det(VALUE self){
   nmatrix* matrix;
-  Data_Get_Struct(self, nmatrix, matrix);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, matrix);
 
   int n = (int)matrix->shape[1];
   int m = (int)matrix->shape[0];
@@ -1355,8 +1355,8 @@ VALUE nm_det(VALUE self){
 VALUE nm_least_square(VALUE self, VALUE rhs_val){
   nmatrix* lhs;
   nmatrix* rhs;
-  Data_Get_Struct(self, nmatrix, lhs);
-  Data_Get_Struct(rhs_val, nmatrix, rhs);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, lhs);
+  TypedData_Get_Struct(rhs_val, nmatrix, &nm_data_type, rhs);
 
   int m = (int)lhs->shape[0];
   int n = (int)lhs->shape[1];
@@ -1407,7 +1407,7 @@ VALUE nm_least_square(VALUE self, VALUE rhs_val){
 
   //LAPACKE_dgels(LAPACK_ROW_MAJOR,'N',m,n,nrhs,lhs_elements,lda,rhs_elements,ldb);
 
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }
 
 VALUE nm_pinv(VALUE self){
@@ -1438,7 +1438,7 @@ VALUE nm_lu(VALUE self){
 
 VALUE nm_lu_factor(VALUE self){
   nmatrix* matrix;
-  Data_Get_Struct(self, nmatrix, matrix);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, matrix);
 
   nmatrix* result_lu = ALLOC(nmatrix);
   result_lu->dtype = matrix->dtype;
@@ -1470,8 +1470,8 @@ VALUE nm_lu_factor(VALUE self){
   result_piv->elements = ipiv;
 
   VALUE ary = rb_ary_new();
-  rb_ary_push(ary, Data_Wrap_Struct(NMatrix, NULL, nm_free, result_lu));
-  rb_ary_push(ary, Data_Wrap_Struct(NMatrix, NULL, nm_free, result_piv));
+  rb_ary_push(ary, TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_lu));
+  rb_ary_push(ary, TypedData_Wrap_Struct(NMatrix, &nm_data_type, result_piv));
 
   return ary;
 }

--- a/ext/ruby_nmatrix.c
+++ b/ext/ruby_nmatrix.c
@@ -133,6 +133,7 @@ static const rb_data_type_t nm_data_type = {
 
 typedef struct NMATRIX_BUFFER_STRUCT
 {
+  nm_dtype dtype;
   size_t count;
   size_t ndims;
   size_t* shape;
@@ -537,7 +538,7 @@ void get_dense_from_dia(const void* data_t, const size_t rows,
                        void* elements_t, nm_dtype);
 
 //forwards for internally used functions
-void get_slice(nmatrix* nmat, size_t* lower, size_t* upper, nmatrix* slice);
+void get_slice(nmatrix* nmat, size_t* lower, size_t* upper, nmatrix_buffer* slice);
 size_t get_index(nmatrix* nmat, VALUE* indices);
 
 

--- a/ext/ruby_nmatrix.c
+++ b/ext/ruby_nmatrix.c
@@ -118,6 +118,19 @@ typedef struct NMATRIX_STRUCT
   sparse_storage* sp;
 }nmatrix;
 
+void nm_free(void* ptr);
+size_t nm_memsize(const void* ptr);
+
+static const rb_data_type_t nm_data_type = {
+  "numruby/nmatrix",
+  {
+    0,
+    nm_free,
+    nm_memsize,
+  },
+  0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 nmatrix* nmatrix_new(
   nm_dtype dtype,
   nm_stype stype,
@@ -354,7 +367,6 @@ VALUE nm_get_dim(VALUE self);
 VALUE nm_get_elements(VALUE self);
 VALUE nm_get_shape(VALUE self);
 VALUE nm_alloc(VALUE klass);
-void nm_free(nmatrix* mat);
 
 VALUE nm_each(VALUE self);
 VALUE nm_each_with_indices(VALUE self);
@@ -695,7 +707,7 @@ VALUE constant_nmatrix(int argc, VALUE* argv, double constant){
 
   mat->elements = elements;
 
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, mat);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, mat);
 }
 
 /*
@@ -720,7 +732,7 @@ VALUE constant_nmatrix(int argc, VALUE* argv, double constant){
  */
 VALUE nmatrix_init(int argc, VALUE* argv, VALUE self){
   nmatrix* mat;
-  Data_Get_Struct(self, nmatrix, mat);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, mat);
 
   if(argc > 0){
     mat->ndims = (size_t)RARRAY_LEN(argv[0]);
@@ -842,21 +854,32 @@ VALUE nm_alloc(VALUE klass)
 {
   nmatrix* mat = ALLOC(nmatrix);
 
-  return Data_Wrap_Struct(klass, NULL, nm_free, mat);
+  return TypedData_Wrap_Struct(klass, &nm_data_type, mat);
 }
 
 /*
  * Destructor.
  */
-void nm_free(nmatrix* mat){
+void nm_free(void* ptr){
+  nmatrix *mat = (nmatrix*)ptr;
+  if (mat->shape) xfree(mat->shape);
+  if (mat->elements) xfree(mat->elements);
   xfree(mat);
+}
+
+size_t nm_memsize(const void* ptr){
+  nmatrix *mat = (nmatrix*)ptr;
+  size_t size = sizeof(mat);
+  if (mat->shape) size += mat->ndims;
+  if (mat->elements) size += mat->count;
+  return size;
 }
 
 // Returns number of dimensions of matrix
 VALUE nm_get_dim(VALUE self){
   nmatrix* input;
 
-  Data_Get_Struct(self, nmatrix, input);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, input);
 
   return INT2NUM(input->ndims);
 }
@@ -864,7 +887,7 @@ VALUE nm_get_dim(VALUE self){
 // Returns a flat list(one dimensional array) of elements values of matrix
 VALUE nm_get_elements(VALUE self){
   nmatrix* input;
-  Data_Get_Struct(self, nmatrix, input);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, input);
 
   size_t count = input->count;
   VALUE* array = NULL;
@@ -955,7 +978,7 @@ VALUE nm_get_elements(VALUE self){
 VALUE nm_get_shape(VALUE self){
   nmatrix* input;
 
-  Data_Get_Struct(self, nmatrix, input);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, input);
 
   VALUE* array = ALLOC_N(VALUE, input->ndims);
   for (size_t index = 0; index < input->ndims; index++){
@@ -974,7 +997,7 @@ VALUE nm_get_shape(VALUE self){
  */
 VALUE nm_get_dtype(VALUE self){
   nmatrix* nmat;
-  Data_Get_Struct(self, nmatrix, nmat);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, nmat);
 
   return ID2SYM(rb_intern(DTYPE_NAMES[nmat->dtype]));
 }
@@ -987,7 +1010,7 @@ VALUE nm_get_dtype(VALUE self){
  */
 VALUE nm_get_stype(VALUE self){
   nmatrix* nmat;
-  Data_Get_Struct(self, nmatrix, nmat);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, nmat);
 
   return ID2SYM(rb_intern(STYPE_NAMES[nmat->stype]));
 }
@@ -1027,7 +1050,7 @@ void increment_state(VALUE* state_array, VALUE* shape_array, size_t ndims) {
 // Return rank of the matrix
 VALUE nm_get_rank(VALUE self, VALUE dim_val){
   nmatrix* input;
-  Data_Get_Struct(self, nmatrix, input);
+  TypedData_Get_Struct(self, nmatrix, &nm_data_type, input);
   double* input_elements = (double*)input->elements;
 
   size_t dim = NUM2LONG(dim_val);
@@ -1049,7 +1072,7 @@ VALUE nm_get_rank(VALUE self, VALUE dim_val){
     result_elements[i] = input_elements[input->shape[1]*dim + i];
   result->elements = result_elements;
 
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }
 
 VALUE nm_inspect(VALUE self){

--- a/ext/ruby_nmatrix.c
+++ b/ext/ruby_nmatrix.c
@@ -131,6 +131,28 @@ static const rb_data_type_t nm_data_type = {
   0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 
+typedef struct NMATRIX_BUFFER_STRUCT
+{
+  size_t count;
+  size_t ndims;
+  size_t* shape;
+  void* buffer_ele_start_ptr;
+  nmatrix* mat;
+}nmatrix_buffer;
+
+void nm_buffer_free(void* ptr);
+size_t nm_buffer_memsize(const void* ptr);
+
+static const rb_data_type_t nm_buffer_data_type = {
+  "numruby/nmatrix_buffer",
+  {
+    0,
+    nm_buffer_free,
+    nm_buffer_memsize,
+  },
+  0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 nmatrix* nmatrix_new(
   nm_dtype dtype,
   nm_stype stype,
@@ -872,6 +894,19 @@ size_t nm_memsize(const void* ptr){
   size_t size = sizeof(mat);
   if (mat->shape) size += mat->ndims;
   if (mat->elements) size += mat->count;
+  return size;
+}
+
+void nm_buffer_free(void* ptr){
+  nmatrix_buffer *mat_buf = (nmatrix_buffer*)ptr;
+  if (mat_buf->shape) xfree(mat_buf->shape);
+  xfree(mat_buf);
+}
+
+size_t nm_buffer_memsize(const void* ptr){
+  nmatrix_buffer *mat_buf = (nmatrix_buffer*)ptr;
+  size_t size = sizeof(mat_buf);
+  if (mat_buf->shape) size += mat_buf->ndims;
   return size;
 }
 

--- a/ext/slicing.c
+++ b/ext/slicing.c
@@ -1,6 +1,6 @@
 /*
  * converts Range objects to corresponding
- * lower limt and upper limit and put them in size_t varibles
+ * lower limit and upper limit and put them in size_t variables
  */
 void parse_ranges(nmatrix* nmat, VALUE* indices, size_t* lower, size_t* upper){
 

--- a/ext/slicing.c
+++ b/ext/slicing.c
@@ -52,7 +52,7 @@ void parse_ranges(nmatrix* nmat, VALUE* indices, size_t* lower, size_t* upper){
  *
  *
  */
-void get_slice(nmatrix* nmat, size_t* lower, size_t* upper, nmatrix* slice){
+void get_slice(nmatrix* nmat, size_t* lower, size_t* upper, nmatrix_buffer* slice){
   /*
     parse the indices to form ranges for C loops
 
@@ -84,203 +84,215 @@ void get_slice(nmatrix* nmat, size_t* lower, size_t* upper, nmatrix* slice){
     slice->shape[slice_ind++] = dim_length;
   }
 
-
-  //mark elements that are inside the slice
-  //and copy them to elements array of slice
-
   VALUE* state_array = ALLOC_N(VALUE, nmat->ndims);
   for(size_t i = 0; i < nmat->ndims; ++i){
     state_array[i] = SIZET2NUM(lower[i]);
   }
 
-  switch (nmat->dtype){
-    case nm_bool:
-    {
-      bool* nmat_elements = (bool*)nmat->elements;
+  // for float64
+  double* nmat_elements = (double*)nmat->elements;
+  size_t start_index = get_index(nmat, state_array);  // slice first element index in elements array
+  slice->buffer_ele_start_ptr = (nmat_elements + start_index);
 
-      bool* slice_elements = ALLOC_N(bool, slice->count);
+  //mark elements that are inside the slice
+  //and copy them to elements array of slice
 
-      for(size_t i = 0; i < slice->count; ++i){
-        size_t nmat_index = get_index(nmat, state_array);
-        slice_elements[i] = nmat_elements[nmat_index];
+  // below code is moved to get_elements func
+  // as on using nmatrix buffer,
+  // the elements doesn't need to be copied
+  // but the iteration of elements needs to
+  // be done using the starting element of buffer
+  // and original shape strides
 
-        size_t state_index = (nmat->ndims) - 1;
-        while(true){
-          size_t curr_index_value = NUM2SIZET(state_array[state_index]);
 
-          if(curr_index_value == upper[state_index]){
-            curr_index_value = lower[state_index];
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-          }
-          else{
-            curr_index_value++;
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-            break;
-          }  
+  // switch (nmat->dtype){
+  //   case nm_bool:
+  //   {
+  //     bool* nmat_elements = (bool*)nmat->elements;
 
-          state_index--;        
-        }
-      }
+  //     bool* slice_elements = ALLOC_N(bool, slice->count);
 
-      slice->elements = slice_elements;
-      break;
-    }
-    case nm_int:
-    {
-      int* nmat_elements = (int*)nmat->elements;
+  //     for(size_t i = 0; i < slice->count; ++i){
+  //       size_t nmat_index = get_index(nmat, state_array);
+  //       slice_elements[i] = nmat_elements[nmat_index];
 
-      int* slice_elements = ALLOC_N(int, slice->count);
+  //       size_t state_index = (nmat->ndims) - 1;
+  //       while(true){
+  //         size_t curr_index_value = NUM2SIZET(state_array[state_index]);
 
-      for(size_t i = 0; i < slice->count; ++i){
-        size_t nmat_index = get_index(nmat, state_array);
-        slice_elements[i] = nmat_elements[nmat_index];
+  //         if(curr_index_value == upper[state_index]){
+  //           curr_index_value = lower[state_index];
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //         }
+  //         else{
+  //           curr_index_value++;
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //           break;
+  //         }  
 
-        size_t state_index = (nmat->ndims) - 1;
-        while(true){
-          size_t curr_index_value = NUM2SIZET(state_array[state_index]);
+  //         state_index--;        
+  //       }
+  //     }
 
-          if(curr_index_value == upper[state_index]){
-            curr_index_value = lower[state_index];
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-          }
-          else{
-            curr_index_value++;
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-            break;
-          }  
+  //     slice->elements = slice_elements;
+  //     break;
+  //   }
+  //   case nm_int:
+  //   {
+  //     int* nmat_elements = (int*)nmat->elements;
 
-          state_index--;        
-        }
-      }
+  //     int* slice_elements = ALLOC_N(int, slice->count);
 
-      slice->elements = slice_elements;
-      break;
-    }
-    case nm_float64:
-    {
-      double* nmat_elements = (double*)nmat->elements;
+  //     for(size_t i = 0; i < slice->count; ++i){
+  //       size_t nmat_index = get_index(nmat, state_array);
+  //       slice_elements[i] = nmat_elements[nmat_index];
 
-      double* slice_elements = ALLOC_N(double, slice->count);
+  //       size_t state_index = (nmat->ndims) - 1;
+  //       while(true){
+  //         size_t curr_index_value = NUM2SIZET(state_array[state_index]);
 
-      for(size_t i = 0; i < slice->count; ++i){
-        size_t nmat_index = get_index(nmat, state_array);
-        slice_elements[i] = nmat_elements[nmat_index];
+  //         if(curr_index_value == upper[state_index]){
+  //           curr_index_value = lower[state_index];
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //         }
+  //         else{
+  //           curr_index_value++;
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //           break;
+  //         }  
 
-        size_t state_index = (nmat->ndims) - 1;
-        while(true){
-          size_t curr_index_value = NUM2SIZET(state_array[state_index]);
+  //         state_index--;        
+  //       }
+  //     }
 
-          if(curr_index_value == upper[state_index]){
-            curr_index_value = lower[state_index];
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-          }
-          else{
-            curr_index_value++;
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-            break;
-          }  
+  //     slice->elements = slice_elements;
+  //     break;
+  //   }
+  //   case nm_float64:
+  //   {
+  //     double* nmat_elements = (double*)nmat->elements;
 
-          state_index--;        
-        }
-      }
+  //     double* slice_elements = ALLOC_N(double, slice->count);
 
-      slice->elements = slice_elements;
-      break;
-    }
-    case nm_float32:
-    {
-      float* nmat_elements = (float*)nmat->elements;
+  //     for(size_t i = 0; i < slice->count; ++i){
+  //       size_t nmat_index = get_index(nmat, state_array);
+  //       slice_elements[i] = nmat_elements[nmat_index];
 
-      float* slice_elements = ALLOC_N(float, slice->count);
+  //       size_t state_index = (nmat->ndims) - 1;
+  //       while(true){
+  //         size_t curr_index_value = NUM2SIZET(state_array[state_index]);
 
-      for(size_t i = 0; i < slice->count; ++i){
-        size_t nmat_index = get_index(nmat, state_array);
-        slice_elements[i] = nmat_elements[nmat_index];
+  //         if(curr_index_value == upper[state_index]){
+  //           curr_index_value = lower[state_index];
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //         }
+  //         else{
+  //           curr_index_value++;
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //           break;
+  //         }  
 
-        size_t state_index = (nmat->ndims) - 1;
-        while(true){
-          size_t curr_index_value = NUM2SIZET(state_array[state_index]);
+  //         state_index--;        
+  //       }
+  //     }
 
-          if(curr_index_value == upper[state_index]){
-            curr_index_value = lower[state_index];
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-          }
-          else{
-            curr_index_value++;
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-            break;
-          }  
+  //     slice->elements = slice_elements;
+  //     break;
+  //   }
+  //   case nm_float32:
+  //   {
+  //     float* nmat_elements = (float*)nmat->elements;
 
-          state_index--;        
-        }
-      }
+  //     float* slice_elements = ALLOC_N(float, slice->count);
 
-      slice->elements = slice_elements;
-      break;
-    }
-    case nm_complex32:
-    {
-      float complex* nmat_elements = (float complex*)nmat->elements;
+  //     for(size_t i = 0; i < slice->count; ++i){
+  //       size_t nmat_index = get_index(nmat, state_array);
+  //       slice_elements[i] = nmat_elements[nmat_index];
 
-      float complex* slice_elements = ALLOC_N(float complex, slice->count);
+  //       size_t state_index = (nmat->ndims) - 1;
+  //       while(true){
+  //         size_t curr_index_value = NUM2SIZET(state_array[state_index]);
 
-      for(size_t i = 0; i < slice->count; ++i){
-        size_t nmat_index = get_index(nmat, state_array);
-        slice_elements[i] = nmat_elements[nmat_index];
+  //         if(curr_index_value == upper[state_index]){
+  //           curr_index_value = lower[state_index];
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //         }
+  //         else{
+  //           curr_index_value++;
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //           break;
+  //         }  
 
-        size_t state_index = (nmat->ndims) - 1;
-        while(true){
-          size_t curr_index_value = NUM2SIZET(state_array[state_index]);
+  //         state_index--;        
+  //       }
+  //     }
 
-          if(curr_index_value == upper[state_index]){
-            curr_index_value = lower[state_index];
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-          }
-          else{
-            curr_index_value++;
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-            break;
-          }  
+  //     slice->elements = slice_elements;
+  //     break;
+  //   }
+  //   case nm_complex32:
+  //   {
+  //     float complex* nmat_elements = (float complex*)nmat->elements;
 
-          state_index--;        
-        }
-      }
+  //     float complex* slice_elements = ALLOC_N(float complex, slice->count);
 
-      slice->elements = slice_elements;
-      break;
-    }
-    case nm_complex64:
-    {
-      double complex* nmat_elements = (double complex*)nmat->elements;
+  //     for(size_t i = 0; i < slice->count; ++i){
+  //       size_t nmat_index = get_index(nmat, state_array);
+  //       slice_elements[i] = nmat_elements[nmat_index];
 
-      double complex* slice_elements = ALLOC_N(double complex, slice->count);
+  //       size_t state_index = (nmat->ndims) - 1;
+  //       while(true){
+  //         size_t curr_index_value = NUM2SIZET(state_array[state_index]);
 
-      for(size_t i = 0; i < slice->count; ++i){
-        size_t nmat_index = get_index(nmat, state_array);
-        slice_elements[i] = nmat_elements[nmat_index];
+  //         if(curr_index_value == upper[state_index]){
+  //           curr_index_value = lower[state_index];
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //         }
+  //         else{
+  //           curr_index_value++;
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //           break;
+  //         }  
 
-        size_t state_index = (nmat->ndims) - 1;
-        while(true){
-          size_t curr_index_value = NUM2SIZET(state_array[state_index]);
+  //         state_index--;        
+  //       }
+  //     }
 
-          if(curr_index_value == upper[state_index]){
-            curr_index_value = lower[state_index];
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-          }
-          else{
-            curr_index_value++;
-            state_array[state_index] = SIZET2NUM(curr_index_value);
-            break;
-          }  
+  //     slice->elements = slice_elements;
+  //     break;
+  //   }
+  //   case nm_complex64:
+  //   {
+  //     double complex* nmat_elements = (double complex*)nmat->elements;
 
-          state_index--;        
-        }
-      }
+  //     double complex* slice_elements = ALLOC_N(double complex, slice->count);
 
-      slice->elements = slice_elements;
-      break;
-    }
-  }
+  //     for(size_t i = 0; i < slice->count; ++i){
+  //       size_t nmat_index = get_index(nmat, state_array);
+  //       slice_elements[i] = nmat_elements[nmat_index];
+
+  //       size_t state_index = (nmat->ndims) - 1;
+  //       while(true){
+  //         size_t curr_index_value = NUM2SIZET(state_array[state_index]);
+
+  //         if(curr_index_value == upper[state_index]){
+  //           curr_index_value = lower[state_index];
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //         }
+  //         else{
+  //           curr_index_value++;
+  //           state_array[state_index] = SIZET2NUM(curr_index_value);
+  //           break;
+  //         }  
+
+  //         state_index--;        
+  //       }
+  //     }
+
+  //     slice->elements = slice_elements;
+  //     break;
+  //   }
+  // }
 
   //fill the nmatrix* slice with the req data
 }

--- a/ext/sparse.c
+++ b/ext/sparse.c
@@ -4,7 +4,7 @@ VALUE nm_sparse_alloc(VALUE klass)
 {
   csr_nmatrix* mat = ALLOC(csr_nmatrix);
 
-  return Data_Wrap_Struct(klass, NULL, nm_free, mat);
+  return TypedData_Wrap_Struct(klass, &nm_data_type, mat);
 }
 
 //frees the memeory allocated to the given sparse matrix object
@@ -99,7 +99,7 @@ VALUE coo_sparse_nmatrix_init(int argc, VALUE* argv){
     }
   }
 
-  return Data_Wrap_Struct(SparseNMatrix, NULL, nm_free, mat);
+  return TypedData_Wrap_Struct(SparseNMatrix, &nm_data_type, mat);
 }
 
 //initializes the sparse matrix of type CSR
@@ -189,7 +189,7 @@ VALUE csr_sparse_nmatrix_init(int argc, VALUE* argv){
     }
   }
 
-  return Data_Wrap_Struct(SparseNMatrix, NULL, nm_free, mat);
+  return TypedData_Wrap_Struct(SparseNMatrix, &nm_data_type, mat);
 }
 
 //initializes the sparse matrix of type CSC
@@ -279,7 +279,7 @@ VALUE csc_sparse_nmatrix_init(int argc, VALUE* argv){
     }
   }
 
-  return Data_Wrap_Struct(SparseNMatrix, NULL, nm_free, mat);
+  return TypedData_Wrap_Struct(SparseNMatrix, &nm_data_type, mat);
 }
 
 //initializes the sparse matrix of type Dia
@@ -365,13 +365,13 @@ VALUE dia_sparse_nmatrix_init(int argc, VALUE* argv){
     }
   }
 
-  return Data_Wrap_Struct(SparseNMatrix, NULL, nm_free, mat);
+  return TypedData_Wrap_Struct(SparseNMatrix, &nm_data_type, mat);
 }
 
 //return the dtype of given sparse matrix
 VALUE nm_sparse_get_dtype(VALUE self){
   sparse_nmatrix* spmat;
-  Data_Get_Struct(self, sparse_nmatrix, spmat);
+  TypedData_Get_Struct(self, sparse_nmatrix, &nm_data_type, spmat);
 
   return rb_str_new_cstr(DTYPE_NAMES[spmat->dtype]);
 }
@@ -380,7 +380,7 @@ VALUE nm_sparse_get_dtype(VALUE self){
 VALUE nm_sparse_get_shape(VALUE self){
   sparse_nmatrix* input;
 
-  Data_Get_Struct(self, sparse_nmatrix, input);
+  TypedData_Get_Struct(self, sparse_nmatrix, &nm_data_type, input);
 
   VALUE* array = ALLOC_N(VALUE, input->ndims);
   for (size_t index = 0; index < input->ndims; index++){
@@ -393,7 +393,7 @@ VALUE nm_sparse_get_shape(VALUE self){
 //converts given sparse matrix to a flat list of elements
 VALUE nm_sparse_to_array(VALUE self){
   sparse_nmatrix* input;
-  Data_Get_Struct(self, sparse_nmatrix, input);
+  TypedData_Get_Struct(self, sparse_nmatrix, &nm_data_type, input);
 
   size_t count = input->count;
   VALUE* array = ALLOC_N(VALUE, input->count);
@@ -556,7 +556,7 @@ VALUE nm_sparse_to_array(VALUE self){
 //on the type of sparse matrix
 VALUE nm_sparse_to_nmatrix(VALUE self){
   sparse_nmatrix* input;
-  Data_Get_Struct(self, sparse_nmatrix, input);
+  TypedData_Get_Struct(self, sparse_nmatrix, &nm_data_type, input);
 
   nmatrix* result = ALLOC(nmatrix);
   result->dtype = input->dtype;
@@ -654,7 +654,7 @@ VALUE nm_sparse_to_nmatrix(VALUE self){
   }
 
 
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }
 
 //extracts elements from coo type sparse matrix

--- a/ext/sparse.c
+++ b/ext/sparse.c
@@ -430,6 +430,11 @@ VALUE nm_sparse_to_array(VALUE self){
       elements_t = ALLOC_N(double complex, count);
       break;
     }
+    default:
+    {
+      elements_t = ALLOC_N(double, count);
+      break;
+    }
   }
 
   switch (input->sptype) {
@@ -470,6 +475,16 @@ VALUE nm_sparse_to_array(VALUE self){
                         input->shape[1],
                         input->diag->offset,
                         elements_t, nm_float64);
+      break;
+    }
+    default:
+    {
+      get_dense_from_coo(input->coo->elements,
+                        input->shape[0],
+                        input->shape[1],
+                        input->coo->ia,
+                        input->coo->ja,
+                        elements_t, input->dtype);
       break;
     }
   }
@@ -520,6 +535,14 @@ VALUE nm_sparse_to_array(VALUE self){
       double complex* elements = elements_t;
       for (size_t index = 0; index < count; index++){
         array[index] = rb_complex_new(DBL2NUM(creal(elements[index])), DBL2NUM(cimag(elements[index])));
+      }
+      break;
+    }
+    default:
+    {
+      double* elements = elements_t;
+      for (size_t index = 0; index < count; index++){
+        array[index] = DBL2NUM(elements[index]);
       }
       break;
     }
@@ -575,6 +598,11 @@ VALUE nm_sparse_to_nmatrix(VALUE self){
     case nm_complex64:
     {
       elements_t = ALLOC_N(double complex, result->count);
+      break;
+    }
+    default:
+    {
+      elements_t = ALLOC_N(double, result->count);
       break;
     }
   }
@@ -653,7 +681,7 @@ void get_dense_from_coo(const void* data_t, const size_t rows,
     }
     case nm_int:
     {
-      const const int* data = data_t;
+      const int* data = data_t;
       int* elements = elements_t;
       for(size_t i = 0; i < rows*cols; ++i){ elements[i] = 0; }
 

--- a/ext/statistics.c
+++ b/ext/statistics.c
@@ -9,12 +9,12 @@
  */
 VALUE average_nmatrix(int argc, VALUE* argv){
   nmatrix* matrix;
-  Data_Get_Struct(argv[0], nmatrix, matrix);
+  TypedData_Get_Struct(argv[0], nmatrix, &nm_data_type, matrix);
 
   size_t axis = NUM2LONG(argv[1]);
 
   nmatrix* weights;
-  Data_Get_Struct(argv[2], nmatrix, weights);
+  TypedData_Get_Struct(argv[2], nmatrix, &nm_data_type, weights);
   double* weight_elements = weights->elements;
 
   nmatrix* result = ALLOC(nmatrix);
@@ -54,5 +54,5 @@ VALUE average_nmatrix(int argc, VALUE* argv){
     result->elements = result_elements;
   }
 
-  return Data_Wrap_Struct(NMatrix, NULL, nm_free, result);
+  return TypedData_Wrap_Struct(NMatrix, &nm_data_type, result);
 }


### PR DESCRIPTION
* Added the nmatrix_buffer struct
* Used buffer in slicing
* Used TypedData_*_Struct
* Fixed some warnings

The way buffer is used in slicing is that when slicing is called, instead of copying the elements into new nmatrix struct, a nmatrix_buffer struct is created and just the elements pointer to used to create the pointer of buffer matrix which removes the copying of elements and hence preventing a copy.

Also, nmatrix_buffer points to the original matrix and uses the original shape to create strides which are used in conjunction with buffer elements starting pointer to correctly access the sliced matrix elements from the original matrix elements array. This makes the sliced matrix as a view to the original matrix and one can change the sliced matrix elements and same change can be seen in the original matrix elements.

One can also create a view by doing a slice on a sliced matrix and internally the nmatrix_buffer would be created from nmatrix_buffer of given sliced matrix and the original matrix struct which is accessed from the given nmatrix_buffer.